### PR TITLE
address Fauck crash on exit

### DIFF
--- a/source/projects/chuck/core/chuck_dl.cpp
+++ b/source/projects/chuck/core/chuck_dl.cpp
@@ -825,6 +825,16 @@ Chuck_DL_MainThreadHook * CK_DLL_CALL ck_create_main_thread_hook( Chuck_DL_Query
     return new Chuck_DL_MainThreadHook( hook, quit, bindle, query->carrier() );
 }
 
+//-----------------------------------------------------------------------------
+// name: ck_register_callback_on_shutdown() | 1.5.2.5 (ge) added
+// desc: register a callback function to be called on host exit
+//       (both natural or SIGINT)
+//-----------------------------------------------------------------------------
+void CK_DLL_CALL ck_register_callback_on_shutdown( Chuck_DL_Query * query, f_callback_on_shutdown cb, void * bindle )
+{
+    // register
+    query->vm()->register_callback_on_shutdown( cb, bindle );
+}
 
 //-----------------------------------------------------------------------------
 // name: ck_register_shreds_watcher()
@@ -1351,6 +1361,7 @@ Chuck_DL_Query::Chuck_DL_Query( Chuck_Carrier * carrier, Chuck_DLL * dll )
     create_main_thread_hook = ck_create_main_thread_hook;
     register_shreds_watcher = ck_register_shreds_watcher; // 1.5.1.5 (ge & andrew)
     unregister_shreds_watcher = ck_unregister_shreds_watcher; // 1.5.1.5 (ge & andrew)
+    register_callback_on_shutdown = ck_register_callback_on_shutdown; // 1.5.2.5 (ge)
     m_carrier = carrier;
     dll_ref = dll; // 1.5.1.3 (ge) added
 

--- a/source/projects/chuck/core/chuck_dl.h
+++ b/source/projects/chuck/core/chuck_dl.h
@@ -63,7 +63,7 @@
 #define CK_DLL_VERSION_MAJOR (10)
 // minor API version: revisions
 // minor API version of chuck must >= API version of chugin
-#define CK_DLL_VERSION_MINOR (1)
+#define CK_DLL_VERSION_MINOR (2)
 #define CK_DLL_VERSION_MAKE(maj,min) ((t_CKUINT)(((maj) << 16) | (min)))
 #define CK_DLL_VERSION_GETMAJOR(v) (((v) >> 16) & 0xFFFF)
 #define CK_DLL_VERSION_GETMINOR(v) ((v) & 0xFFFF)
@@ -340,6 +340,8 @@ typedef t_CKBOOL (CK_DLL_CALL * f_tock)( Chuck_Object * SELF, Chuck_UAna * UANA,
 typedef t_CKBOOL (CK_DLL_CALL * f_mainthreadhook)( void * bindle );
 // "main thread" quit (stop running hook)
 typedef t_CKBOOL (CK_DLL_CALL * f_mainthreadquit)( void * bindle );
+// callback function, called on host shutdown
+typedef void (CK_DLL_CALL * f_callback_on_shutdown)( void * bindle );
 // shreds watcher callback
 typedef void (CK_DLL_CALL * f_shreds_watcher)( Chuck_VM_Shred * SHRED, t_CKINT CODE, t_CKINT PARAM, Chuck_VM * VM, void * BINDLE );
 // type instantiation callback
@@ -414,6 +416,8 @@ typedef void (CK_DLL_CALL * f_add_ugen_funcf_auto_num_channels)( Chuck_DL_Query 
 typedef t_CKBOOL (CK_DLL_CALL * f_end_class)( Chuck_DL_Query * query );
 // create main thread hook- used for executing a "hook" function in the main thread of a primary chuck instance
 typedef Chuck_DL_MainThreadHook * (CK_DLL_CALL * f_create_main_thread_hook)( Chuck_DL_Query * query, f_mainthreadhook hook, f_mainthreadquit quit, void * bindle );
+// register a callback to be called on host shutdown, e.g., for chugin cleanup
+typedef void (CK_DLL_CALL * f_register_callback_on_shutdown)( Chuck_DL_Query * query, f_callback_on_shutdown cb, void * bindle );
 // register a callback function to receive notification from the VM about shreds (add, remove, etc.)
 typedef void (CK_DLL_CALL * f_register_shreds_watcher)( Chuck_DL_Query * query, f_shreds_watcher cb, t_CKUINT options, void * bindle );
 // unregister a shreds notification callback
@@ -588,6 +592,14 @@ public:
     // deals with graphics or windowing | re-added 1.4.0.1
     // -------------
     f_create_main_thread_hook create_main_thread_hook;
+
+public:
+    // -------------
+    // register a function to be run on host shutdown; this can be used
+    // for chugin cleanup when the host (chuck, miniAudicle, etc.) exits
+    // including on SIGINT (ctrl-c termination) | added 1.5.2.5 (ge)
+    // -------------
+    f_register_callback_on_shutdown register_callback_on_shutdown;
 
 public:
     // -------------

--- a/source/projects/chuck/core/chuck_vm.h
+++ b/source/projects/chuck/core/chuck_vm.h
@@ -413,6 +413,33 @@ public:
 
 
 //-----------------------------------------------------------------------------
+// name: struct Chuck_VM_Callback_On_Shutdown
+// desc: an entry for a callback to be called on VM shutdown
+//-----------------------------------------------------------------------------
+struct Chuck_VM_Callback_On_Shutdown
+{
+    // function pointer to call
+    f_callback_on_shutdown cb;
+    // user data
+    void * userdata;
+
+    // constructor
+    Chuck_VM_Callback_On_Shutdown( f_callback_on_shutdown f = NULL, void * data = NULL )
+    : cb(f), userdata(data) { }
+
+    // copy constructor
+    Chuck_VM_Callback_On_Shutdown( const Chuck_VM_Callback_On_Shutdown & other )
+    : cb(other.cb), userdata(other.userdata) { }
+
+    // ==
+    bool operator ==( const Chuck_VM_Callback_On_Shutdown & other )
+    { return this->cb == other.cb; }
+};
+
+
+
+
+//-----------------------------------------------------------------------------
 // name: struct Chuck_VM_Shreduler
 // desc: a ChucK shreduler shredules shreds
 //-----------------------------------------------------------------------------
@@ -657,6 +684,14 @@ public:
     // remove shreds watcher callback | 1.5.1.5
     void remove_watcher( f_shreds_watcher cb );
 
+public:
+    // register a callback to be called on VM shutdown | 1.5.2.5 (ge) added
+    void register_callback_on_shutdown( f_callback_on_shutdown cb, void * bindle );
+
+protected:
+    // notify callbacks on VM shutdown | 1.5.2.5 (ge) added
+    void notify_callbacks_on_shutdown();
+
 //-----------------------------------------------------------------------------
 // data
 //-----------------------------------------------------------------------------
@@ -733,6 +768,10 @@ protected:
     std::list<Chuck_VM_Shreds_Watcher> m_shreds_watchers_remove;
     std::list<Chuck_VM_Shreds_Watcher> m_shreds_watchers_suspend;
     std::list<Chuck_VM_Shreds_Watcher> m_shreds_watchers_activate;
+
+protected:
+    // 1.5.2.5 (ge) on major VM events callbacks
+    std::list<Chuck_VM_Callback_On_Shutdown> m_callbacks_on_shutdown;
 };
 
 

--- a/source/projects/chugins/chuck/include/chugin.h
+++ b/source/projects/chugins/chuck/include/chugin.h
@@ -115,7 +115,7 @@
 // 1.5.0.0 (ge) | moved to chuck.h for at-a-glance visibility
 // 1.5.2.0 (ge) | moved to chuck_def.h for chugins headers streamlining
 //-----------------------------------------------------------------------------
-#define CHUCK_VERSION_STRING        "1.5.2.4 (chai)"
+#define CHUCK_VERSION_STRING        "1.5.2.5-dev (chai)"
 //-----------------------------------------------------------------------------
 
 
@@ -1158,7 +1158,7 @@ struct a_Program_ { a_Section section; a_Program next; uint32_t line; uint32_t w
 #define CK_DLL_VERSION_MAJOR (10)
 // minor API version: revisions
 // minor API version of chuck must >= API version of chugin
-#define CK_DLL_VERSION_MINOR (1)
+#define CK_DLL_VERSION_MINOR (2)
 #define CK_DLL_VERSION_MAKE(maj,min) ((t_CKUINT)(((maj) << 16) | (min)))
 #define CK_DLL_VERSION_GETMAJOR(v) (((v) >> 16) & 0xFFFF)
 #define CK_DLL_VERSION_GETMINOR(v) ((v) & 0xFFFF)
@@ -1435,6 +1435,8 @@ typedef t_CKBOOL (CK_DLL_CALL * f_tock)( Chuck_Object * SELF, Chuck_UAna * UANA,
 typedef t_CKBOOL (CK_DLL_CALL * f_mainthreadhook)( void * bindle );
 // "main thread" quit (stop running hook)
 typedef t_CKBOOL (CK_DLL_CALL * f_mainthreadquit)( void * bindle );
+// callback function, called on host shutdown
+typedef void (CK_DLL_CALL * f_callback_on_shutdown)( void * bindle );
 // shreds watcher callback
 typedef void (CK_DLL_CALL * f_shreds_watcher)( Chuck_VM_Shred * SHRED, t_CKINT CODE, t_CKINT PARAM, Chuck_VM * VM, void * BINDLE );
 // type instantiation callback
@@ -1509,6 +1511,8 @@ typedef void (CK_DLL_CALL * f_add_ugen_funcf_auto_num_channels)( Chuck_DL_Query 
 typedef t_CKBOOL (CK_DLL_CALL * f_end_class)( Chuck_DL_Query * query );
 // create main thread hook- used for executing a "hook" function in the main thread of a primary chuck instance
 typedef Chuck_DL_MainThreadHook * (CK_DLL_CALL * f_create_main_thread_hook)( Chuck_DL_Query * query, f_mainthreadhook hook, f_mainthreadquit quit, void * bindle );
+// register a callback to be called on host shutdown, e.g., for chugin cleanup
+typedef void (CK_DLL_CALL * f_register_callback_on_shutdown)( Chuck_DL_Query * query, f_callback_on_shutdown cb, void * bindle );
 // register a callback function to receive notification from the VM about shreds (add, remove, etc.)
 typedef void (CK_DLL_CALL * f_register_shreds_watcher)( Chuck_DL_Query * query, f_shreds_watcher cb, t_CKUINT options, void * bindle );
 // unregister a shreds notification callback
@@ -1683,6 +1687,14 @@ public:
     // deals with graphics or windowing | re-added 1.4.0.1
     // -------------
     f_create_main_thread_hook create_main_thread_hook;
+
+public:
+    // -------------
+    // register a function to be run on host shutdown; this can be used
+    // for chugin cleanup on the host (chuck, miniAudicle, etc.) exits
+    // added 1.5.2.5 (ge)
+    // -------------
+    f_register_callback_on_shutdown register_callback_on_shutdown;
 
 public:
     // -------------


### PR DESCRIPTION
effort to fix Fauck crash-on-exit.
* added a mechanism in Faust.cpp (the chugin binding) to track allocated Faust objects; on VM shutdown (including preemptive external shutdowns e.g., SIGINT or application exit) any outstanding Faust objects will be cleaned up
* added the ability for a chugin to register a callback on host/VM shutdown
* chugin API version is bumped from 10.1 to 10.2 here (note the chugin API version here is currently ahead of `chuck` tip-of-main; this will be brought to parity on the upcoming 1.5.2.5 release)
* new `chugin.h`